### PR TITLE
Fix broken submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libc-database"]
-    path = libc-database
-    url = https://github.com/lieanu/libc-database.git
+	path = libc-database
+	url = https://github.com/lieanu/libc-database.git


### PR DESCRIPTION
The old submodule `libc-database @ 4ebb57b` is broken. Updated to the latest commit in this PR.